### PR TITLE
Add dashboard endpoint

### DIFF
--- a/api/dashboard/urls.py
+++ b/api/dashboard/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path("get/", views.get_dashboard),
+]

--- a/api/dashboard/utils.py
+++ b/api/dashboard/utils.py
@@ -1,0 +1,18 @@
+from api.models import UserEvent
+
+
+def get_event_type(date_type):
+    match date_type:
+        case UserEvent.EventType.SPECIFIC:
+            return "Date"
+        case UserEvent.EventType.GENERIC:
+            return "Week"
+
+
+def format_event(event):
+    return {
+        "title": event.title,
+        "event_type": get_event_type(event.date_type),
+        "participants": [p.display_name for p in event.participants.all()],
+        "event_code": event.url_codes.first().url_code,
+    }

--- a/api/dashboard/views.py
+++ b/api/dashboard/views.py
@@ -5,6 +5,7 @@ from django.db.models import Q
 from rest_framework import serializers
 from rest_framework.response import Response
 
+from api.dashboard.utils import format_event
 from api.models import EventParticipant, UserEvent
 from api.settings import GENERIC_ERR_RESPONSE
 from api.utils import api_endpoint, require_auth, validate_output
@@ -34,6 +35,8 @@ def get_dashboard(request):
     Returns dashboard data for the current user. This includes events that the user
     created and ones that the user participated in.
 
+    The events are sorted by their creation date.
+
     Events that no longer have a URL code from inactivity will not be included.
     """
     user = request.user
@@ -41,35 +44,17 @@ def get_dashboard(request):
     try:
         created_events = UserEvent.objects.filter(
             user_account=user, url_codes__isnull=False
-        )
+        ).order_by("created_at")
         # Don't include events that the user both created and participated in
-        participated_events = EventParticipant.objects.filter(
+        participants = EventParticipant.objects.filter(
             ~Q(user_event__user_account=user),
             user_account=user,
             user_event__url_codes__isnull=False,
-        )
+        ).order_by("user_event__created_at")
 
-        my_events = [
-            {
-                "title": event.title,
-                "event_type": ("Date" if event.date_type == "SPECIFIC" else "Week"),
-                "participants": [p.display_name for p in event.participants.all()],
-                "event_code": event.url_codes.first().url_code,
-            }
-            for event in created_events
-        ]
+        my_events = [format_event(event) for event in created_events]
         their_events = [
-            {
-                "title": event.user_event.title,
-                "event_type": (
-                    "Date" if event.user_event.date_type == "SPECIFIC" else "Week"
-                ),
-                "participants": [
-                    p.display_name for p in event.user_event.participants.all()
-                ],
-                "event_code": event.user_event.url_codes.first().url_code,
-            }
-            for event in participated_events
+            format_event(participant.user_event) for participant in participants
         ]
 
     except DatabaseError as e:

--- a/api/dashboard/views.py
+++ b/api/dashboard/views.py
@@ -1,0 +1,82 @@
+import logging
+
+from django.db import DatabaseError
+from django.db.models import Q
+from rest_framework import serializers
+from rest_framework.response import Response
+
+from api.models import EventParticipant, UserEvent
+from api.settings import GENERIC_ERR_RESPONSE
+from api.utils import api_endpoint, require_auth, validate_output
+
+logger = logging.getLogger("api")
+
+
+class EventSerializer(serializers.Serializer):
+    title = serializers.CharField(required=True)
+    event_type = serializers.ChoiceField(required=True, choices=["Date", "Week"])
+    participants = serializers.ListField(
+        child=serializers.CharField(required=True, max_length=25), required=True
+    )
+    event_code = serializers.CharField(required=True, max_length=255)
+
+
+class DashboardSerializer(serializers.Serializer):
+    created_events = serializers.ListField(child=EventSerializer(), required=True)
+    participated_events = serializers.ListField(child=EventSerializer(), required=True)
+
+
+@api_endpoint("GET")
+@require_auth
+@validate_output(DashboardSerializer)
+def get_dashboard(request):
+    """
+    Returns dashboard data for the current user. This includes events that the user
+    created and ones that the user participated in.
+
+    Events that no longer have a URL code from inactivity will not be included.
+    """
+    user = request.user
+
+    try:
+        created_events = UserEvent.objects.filter(
+            user_account=user, url_codes__isnull=False
+        )
+        # Don't include events that the user both created and participated in
+        participated_events = EventParticipant.objects.filter(
+            ~Q(user_event__user_account=user),
+            user_account=user,
+            user_event__url_codes__isnull=False,
+        )
+
+        my_events = [
+            {
+                "title": event.title,
+                "event_type": ("Date" if event.date_type == "SPECIFIC" else "Week"),
+                "participants": [p.display_name for p in event.participants.all()],
+                "event_code": event.url_codes.first().url_code,
+            }
+            for event in created_events
+        ]
+        their_events = [
+            {
+                "title": event.user_event.title,
+                "event_type": (
+                    "Date" if event.user_event.date_type == "SPECIFIC" else "Week"
+                ),
+                "participants": [
+                    p.display_name for p in event.user_event.participants.all()
+                ],
+                "event_code": event.user_event.url_codes.first().url_code,
+            }
+            for event in participated_events
+        ]
+
+    except DatabaseError as e:
+        logger.db_error(e)
+        return GENERIC_ERR_RESPONSE
+    except Exception as e:
+        logger.error(e)
+        return GENERIC_ERR_RESPONSE
+
+    return Response({"created_events": my_events, "participated_events": their_events})

--- a/api/urls.py
+++ b/api/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path("auth/", include("api.auth.urls")),
     path("event/", include("api.event.urls")),
     path("availability/", include("api.availability.urls")),
+    path("dashboard/", include("api.dashboard.urls")),
 ]


### PR DESCRIPTION
## What?
This PR introduces the dashboard get endpoint. It's pretty simple, you only need one endpoint to just get the data.

### New Endpoints
- `/dashboard/get/` - Gets data for the dashboard, including events that the user created and also ones the user participated in.

That's it.

## Why?
We want users to be able to see all of their events without having to keep a list of links.

## How?
Django has a nice ORM with some... questionable syntax sometimes. It gets the job done.

## Testing?
I ran it a few times. It worked.

## Anything Else?
This should be it for API work! Maybe I'll try my hand at helping frontend...