### PR TITLE
Add CORS policies

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -26,6 +26,8 @@ DEBUG = env.bool("DEBUG", default=False)
 
 ALLOWED_HOSTS = []
 
+BASE_URL = env("BASE_URL")
+
 
 # Application definition
 
@@ -39,7 +41,12 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
 ]
+
+CORS_ALLOW_ALL_ORIGINS = True if DEBUG else False
+
+CORS_ALLOWED_ORIGINS = [BASE_URL]
 
 ROOT_URLCONF = "api.urls"
 
@@ -106,8 +113,6 @@ DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL")
 ADMIN_EMAILS = env.list("ADMIN_EMAILS", default=[])
 SEND_EMAILS = env.bool("SEND_EMAILS", default=False)
 CRITICAL_EMAIL_INTERVAL_SECONDS = 1800  # 30 minutes
-
-BASE_URL = env("BASE_URL")
 
 # Automated tasks
 CELERY_BEAT_SCHEDULE = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ click-plugins==1.1.1.2
 click-repl==0.3.0
 colorama==0.4.6
 Django==5.2
+django-cors-headers==4.9.0
 django-environ==0.12.0
 django-ses==4.4.0
 djangorestframework==3.16.0


### PR DESCRIPTION
Just a quick fix to get the frontend integration working. It wasn't allowing anything from the frontend because the browser actually enforces CORS, unlike Postman.