### PR TITLE
Remove proxy dependency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ BASE_URL=https://example.com
 # The URL of the API server, used for CORS policies (no trailing slash)
 API_URL=https://api.example.com
 
+# The domains for cookies, note the leading dot to include subdomains (like api.example.com)
+COOKIE_DOMAIN=.example.com
+
 # The folder where logs will be stored
 LOG_DIR=filepath
 

--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,9 @@ SEND_EMAILS=False
 
 # Enable debug mode, important to have this false in production for security
 DEBUG=True
+
+# Where you are developing, can be:
+# Local
+# Codespaces
+# This is for cookie functionality, and it only matters if DEBUG is True
+TEST_ENVIRONMENT=Local

--- a/api/auth/views.py
+++ b/api/auth/views.py
@@ -39,6 +39,7 @@ from api.settings import (
 from api.utils import (
     MessageOutputSerializer,
     api_endpoint,
+    delete_session_cookie,
     get_session,
     rate_limit,
     require_account_auth,
@@ -500,7 +501,7 @@ def logout(request):
         return GENERIC_ERR_RESPONSE
 
     response = Response({"message": ["Logged out successfully."]}, status=200)
-    response.delete_cookie(ACCOUNT_COOKIE_NAME)
+    delete_session_cookie(response, ACCOUNT_COOKIE_NAME)
     return response
 
 
@@ -528,5 +529,5 @@ def delete_account(request):
         return GENERIC_ERR_RESPONSE
 
     response = Response({"message": ["Account deleted successfully."]}, status=200)
-    response.delete_cookie(ACCOUNT_COOKIE_NAME)
+    delete_session_cookie(response, ACCOUNT_COOKIE_NAME)
     return response

--- a/api/settings.py
+++ b/api/settings.py
@@ -24,6 +24,11 @@ env = environ.Env()
 SECRET_KEY = env("SECRET_KEY")
 
 DEBUG = env.bool("DEBUG", default=False)
+TEST_ENVIRONMENT = env("TEST_ENVIRONMENT", default="")
+if DEBUG and (TEST_ENVIRONMENT not in ["Local", "Codespaces"]):
+    raise ValueError(
+        "DEBUG is True but TEST_ENVIRONMENT is not set to Local or Codespaces."
+    )
 
 BASE_URL = env("BASE_URL")
 API_URL = env("API_URL")

--- a/api/settings.py
+++ b/api/settings.py
@@ -27,7 +27,7 @@ DEBUG = env.bool("DEBUG", default=False)
 
 BASE_URL = env("BASE_URL")
 API_URL = env("API_URL")
-
+COOKIE_DOMAIN = env("COOKIE_DOMAIN")
 
 # Application definition
 
@@ -44,8 +44,12 @@ MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
 ]
 
+# CORS, CSRF, and allowed hosts settings
 CORS_ALLOW_ALL_ORIGINS = True if DEBUG else False
 CORS_ALLOWED_ORIGINS = [BASE_URL, "http://localhost"]
+CORS_ALLOW_CREDENTIALS = True
+CSRF_TRUSTED_ORIGINS = [BASE_URL, "http://localhost"]
+CSRF_COOKIE_DOMAIN = COOKIE_DOMAIN
 ALLOWED_HOSTS = [urlparse(API_URL).hostname, "localhost"]
 
 ROOT_URLCONF = "api.urls"

--- a/api/utils.py
+++ b/api/utils.py
@@ -23,6 +23,7 @@ from api.settings import (
     LONG_SESS_EXP_SECONDS,
     REST_FRAMEWORK,
     SESS_EXP_SECONDS,
+    TEST_ENVIRONMENT,
 )
 
 logger = logging.getLogger("api")
@@ -105,13 +106,17 @@ def set_session_cookie(response, key, value, is_extended):
     Given a response, sets a session cookie with appropriate parameters.
 
     Mostly just to avoid repeating this 8-line block of code.
+
+    The TEST_ENVIRONMENT environment variable determines the `secure` and `samesite`
+    parameters for testing to allow proper cookie functionality in different testing
+    environments.
     """
     response.set_cookie(
         key=key,
         value=value,
         httponly=True,
-        secure=False if DEBUG else True,
-        samesite="Lax",
+        secure=False if DEBUG and TEST_ENVIRONMENT == "Local" else True,
+        samesite="None" if DEBUG and TEST_ENVIRONMENT == "Codespaces" else "Lax",
         max_age=LONG_SESS_EXP_SECONDS if is_extended else SESS_EXP_SECONDS,
         domain=COOKIE_DOMAIN,
     )

--- a/api/utils.py
+++ b/api/utils.py
@@ -16,6 +16,7 @@ from api.availability.utils import get_weekday_date
 from api.models import UserAccount, UserEvent, UserSession
 from api.settings import (
     ACCOUNT_COOKIE_NAME,
+    COOKIE_DOMAIN,
     GENERIC_ERR_RESPONSE,
     GUEST_COOKIE_NAME,
     LONG_SESS_EXP_SECONDS,
@@ -111,7 +112,17 @@ def set_session_cookie(response, key, value, is_extended):
         secure=True,
         samesite="Lax",
         max_age=LONG_SESS_EXP_SECONDS if is_extended else SESS_EXP_SECONDS,
+        domain=COOKIE_DOMAIN,
     )
+
+
+def delete_session_cookie(response, key):
+    """
+    Given a response, deletes a session cookie.
+
+    The domain needs to be specified to delete the right cookie.
+    """
+    response.delete_cookie(key, domain=COOKIE_DOMAIN)
 
 
 def check_auth(func):
@@ -198,7 +209,7 @@ def check_auth(func):
                 response.data["message"].append(SESS_EXP_MSG)
             else:
                 response.data["message"] = [SESS_EXP_MSG]
-            response.delete_cookie(ACCOUNT_COOKIE_NAME)
+            delete_session_cookie(response, ACCOUNT_COOKIE_NAME)
         return response
 
     return wrapper
@@ -373,7 +384,7 @@ def require_auth(func):
                 response.data["message"].append(SESS_EXP_MSG)
             else:
                 response.data["message"] = [SESS_EXP_MSG]
-            response.delete_cookie(ACCOUNT_COOKIE_NAME)
+            delete_session_cookie(response, ACCOUNT_COOKIE_NAME)
         return response
 
     get_metadata(wrapper).min_auth_required = "Guest"

--- a/api/utils.py
+++ b/api/utils.py
@@ -17,6 +17,7 @@ from api.models import UserAccount, UserEvent, UserSession
 from api.settings import (
     ACCOUNT_COOKIE_NAME,
     COOKIE_DOMAIN,
+    DEBUG,
     GENERIC_ERR_RESPONSE,
     GUEST_COOKIE_NAME,
     LONG_SESS_EXP_SECONDS,
@@ -109,7 +110,7 @@ def set_session_cookie(response, key, value, is_extended):
         key=key,
         value=value,
         httponly=True,
-        secure=True,
+        secure=False if DEBUG else True,
         samesite="Lax",
         max_age=LONG_SESS_EXP_SECONDS if is_extended else SESS_EXP_SECONDS,
         domain=COOKIE_DOMAIN,


### PR DESCRIPTION
This PR makes some changes to the API to allow for cookies from different subdomains. What this means is that the client can directly call `api.plancake.org` and have cookies save instead of being forced to route the API requests through the frontend for same-site reasons.

The `.env` file was also changed to include a setting for the testing environment, which tunes the cookie security settings so they work on different environments.